### PR TITLE
Asset Versioning: Add Bash script and docs for cache busting

### DIFF
--- a/ASSET_VERSIONING.md
+++ b/ASSET_VERSIONING.md
@@ -1,0 +1,29 @@
+# Asset Versioning for Navbar
+
+This site uses a simple Bash script for asset versioning to enable cache busting of static files (e.g., JS, CSS).
+
+## Usage
+
+From the `sites/navbar` directory:
+
+```sh
+./asset-version.sh <asset-file>
+```
+
+- The script computes a SHA-1 hash of the asset file, copies it to a new filename with the hash in the name (e.g., `main.js` → `main.v1a2b3c4d.js`), and prints the new filename.
+- Update your HTML to reference the versioned asset filename for cache busting.
+
+## Example
+
+```sh
+./asset-version.sh navbar.js
+# Output: navbar.v1a2b3c4d.js
+```
+
+## Rationale
+- Follows KISS and UNIX principles: minimal dependencies, portable, and easy to audit.
+- No external tools required beyond Bash and coreutils.
+
+---
+
+For more details, see the main project documentation.

--- a/asset-version.sh
+++ b/asset-version.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# asset-version.sh: Simple asset versioning for cache busting in the navbar site.
+# Usage: ./asset-version.sh <asset-file>
+# Output: Renames <asset-file> to <asset-file>?v=<hash> and prints the new filename.
+
+set -e
+
+if [ $# -ne 1 ]; then
+  echo "Usage: $0 <asset-file>" >&2
+  exit 1
+fi
+
+ASSET="$1"
+if [ ! -f "$ASSET" ]; then
+  echo "Error: File '$ASSET' not found." >&2
+  exit 2
+fi
+
+HASH=$(sha1sum "$ASSET" | awk '{print $1}')
+EXT="${ASSET##*.}"
+BASE="${ASSET%.*}"
+NEW_ASSET="${BASE}.v${HASH:0:8}.${EXT}"
+
+cp "$ASSET" "$NEW_ASSET"
+echo "$NEW_ASSET"


### PR DESCRIPTION
Implements asset versioning for navbar assets using a Bash script. Adds documentation in ASSET_VERSIONING.md.\n\nCloses #3.