### PR TITLE
Test Scaffolding: Add Bash test runner and docs

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -1,0 +1,22 @@
+# Navbar Bash Test Scaffolding
+
+This directory includes a minimal Bash-based test runner for the navbar site's scripts and configuration.
+
+## Usage
+
+From the `sites/navbar` directory:
+
+```sh
+./test-navbar.sh
+```
+
+- Runs basic tests for the asset versioning script and other Bash utilities.
+- Prints PASS/FAIL for each test and exits nonzero on failure.
+
+## Rationale
+- Follows KISS and UNIX principles: no dependencies beyond Bash and coreutils.
+- Easy to extend with more tests as new scripts or features are added.
+
+---
+
+For more details, see the main project documentation.

--- a/test-navbar.sh
+++ b/test-navbar.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# test-navbar.sh: Minimal test runner for the navbar Bash scripts and config
+# Usage: ./test-navbar.sh
+
+set -e
+
+failures=0
+
+echo "[TEST] asset-version.sh: should create versioned asset file"
+touch test.js
+echo "console.log('test');" > test.js
+out=$(./asset-version.sh test.js)
+if [[ $out =~ test.v[0-9a-f]{8}\.js ]] && [ -f "$out" ]; then
+  echo "PASS: asset-version.sh versioned file created: $out"
+  rm "$out"
+else
+  echo "FAIL: asset-version.sh did not create versioned file" >&2
+  failures=$((failures+1))
+fi
+rm test.js
+
+if [ $failures -eq 0 ]; then
+  echo "All tests passed."
+  exit 0
+else
+  echo "$failures test(s) failed."
+  exit 1
+fi


### PR DESCRIPTION
Adds Bash-based test runner for navbar scripts and documents usage in TESTING.md.\n\nCloses #4.